### PR TITLE
poethepoet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ GENERATED_PROJECT := my-project
 .PHONY: ci
 ci: build ## CI Build: Test Sample
 	make install -C $(GENERATED_PROJECT)
-	make test -C $(GENERATED_PROJECT)
-	make check -C $(GENERATED_PROJECT)
+	cd $(GENERATED_PROJECT) && poetry poe test
+	cd $(GENERATED_PROJECT) && poetry poe check
 
 # DEPENDENCIES #################################################################
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,7 @@
     "python_major_version": 3,
     "python_minor_version": 8,
     "max_code_line_length": 120,
+    "use_package_mode": ["Enabled", "Disabled"],
     "year": "{% now 'utc', '%Y' %}",
     "_extensions": ["jinja2_time.TimeExtension"]
   }

--- a/poetry.lock
+++ b/poetry.lock
@@ -364,13 +364,13 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.2"
+version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
 
 [package.dependencies]
@@ -476,13 +476,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
-version = "13.7.0"
+version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
-    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
+    {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
+    {file = "rich-13.7.1.tar.gz", hash = "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"},
 ]
 
 [package.dependencies]
@@ -528,13 +528,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.10.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
-    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
+    {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
+    {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.poetry]
-
 name = "python-module-template"
-version = "1.1.0"
+version = "1.2.0"
 description = "A template for Python libraries."
 authors = ["Jerome Guibert <jguibert@gmail.com>"]
 
@@ -9,3 +8,7 @@ authors = ["Jerome Guibert <jguibert@gmail.com>"]
 python = ">=3.8,<3.12"
 cookiecutter = "*"
 jinja2-time = "^0.2.0"
+
+[build-system]
+requires = ["poetry>=1.1.12"]
+build-backend = "poetry.masonry.api"

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ In 2024, we still use a lot of command into `makefile`, dependencies can be mana
 Install `cookiecutter` and generate a project:
 
 ```
-$ pip install cookiecutter
+$ pip install cookiecutter jinja2-time
 $ cookiecutter gh:geronimo-iia/python-module-template -f
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,14 @@ In 2023, 4 year ever, python is always my favorite language (even if I start wor
 - add github action for check current change on build
 - automate github release, publish on pypi, site documentation on a tag.
 
+In 2024, we still use a lot of command into `makefile`, dependencies can be managed with dependabot on github, so in this flavour :
+
+- Replace makefile with [Poe the Poet](https://poethepoet.natn.io/index.html) as a poetry plugin
+- add dependabot configuration to manage developement and production dependencies update.
+- use dependencies group declaration:
+  - `dev` group for all dev tools
+  - `docs` group which can be installed with `poetry install --with docs`
+- add option for package mode: set it to false when you want to use Poetry only for dependency management but not for packaging.
 
 ## Features
 
@@ -38,14 +46,15 @@ In 2023, 4 year ever, python is always my favorite language (even if I start wor
   * Analysing with [ruff](https://github.com/charliermarsh/ruff)
   * Type checking with `mypy`
   * Running tests with `pytest`
+  * [Poe the Poet](https://poethepoet.natn.io/index.html) for automating common development tasks
 * Preconfigured setup for:
-  * `Makefile` for automating common development tasks
   * [Github workflow](https://guides.github.com/introduction/flow/):
     * 'package': launch an install/test/check on each push and pull request on 'main' branch.
     * 'release": on each tag push, launch:
       - a github release 
       - a pypi publish . You have to configure a secret 'PYPI_TOKEN' in your git repository.
       - a site documentation publication
+  * [dependabot](https://github.com/dependabot) to manage dependencies updates.
 * Documentation:
   * Docstring styling with `pydocstyle`
   * Building documentation with `mkdocs`
@@ -64,20 +73,82 @@ $ cookiecutter gh:geronimo-iia/python-module-template -f
 
 Cookiecutter will ask you for some basic info (your name, project name, python package name, etc.) and generate a base Python project for you.
 
+Poe target list:
+
+| Name                    | Comment                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------- |
+| poetry poe check        | Run linters and static analysis                                                          |
+| poetry poe test         | Run unit tests                                                                           |
+| poetry poe build        | Builds the source and wheels archives (and run check & test target)                      |
+| poetry poe publish      | Publishes the package, previously built with the build command, to the remote repository |
+| poetry poe docs         | Builds  site documentation.                                                              |
+| poetry poe docs-publish | Build and publish site documentation.                                                    |
+| poetry poe clean        | Delete all generated and temporary files                                                 |
+| poetry poe requirements | Generate requirements.txt                                                                |
+|                         |                                                                                          |
+
+You could retrieve those commands with `poetry poe`. It will output something like this :
+
+```
+Poe the Poet - A task runner that works well with poetry.
+version 0.25.0
+
+Result: No task specified.
+
+USAGE
+  poetry poe [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]
+
+GLOBAL OPTIONS
+  -h, --help     Show this help page and exit
+  --version      Print the version and exit
+  -v, --verbose  Increase command output (repeatable)
+  -q, --quiet    Decrease command output (repeatable)
+  -d, --dry-run  Print the task contents but don't actually run it
+  --root PATH    Specify where to find the pyproject.toml
+  --ansi         Force enable ANSI output
+  --no-ansi      Force disable ANSI output
+
+CONFIGURED TASKS
+  build          Build module
+  publish        Publish module
+  check          Run Linter
+  test           Run unit tests
+  docs           Build site documentation
+  docs-publish   Publish site documentation
+  clean          Remove all generated and temporary files
+  requirements   Generate requirements.txt
+```
+
 
 Make Target list:
 
-| Name         | Comment                                                                                         |
-|--------------|-------------------------------------------------------------------------------------------------|
-|              |                                                                                                 |
-| debug-info   | Show poetry debug info                                                                          |
-| install      | Install project dependencies                                                                    |
-| check        | Run linters and static analysis                                                                 |
-| test         | Run unit tests                                                                                  |
-| build        | Builds the source and wheels archives                                                           |
-| build-docs   | Builds  site documentation.                                                                     |
-| tag          | create and push a tag based on current project version. This will launch github release action. |
-| publish      | Publishes the package, previously built with the build command, to the remote repository        |
-| publish-docs | Build and publish site documentation.                                                           |
-| clean        | Delete all generated and temporary files                                                        |
-|              |                                                                                                 |
+| Name                    | Comment                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| make install            | Install project dependencies                                                                    |
+| make configure          | Configure poetry                                                                                |
+| make tag                | Create and push a tag based on current project version. This will launch github release action. |
+| make next-patch-version | Increment patch version of the project.                                                         |
+|                         |                                                                                                 |
+
+## Note on configuration of Poetry
+
+To configure poetry, you could use `make configure`or run :
+
+```bash
+# virtualenvs under project folder
+poetry config virtualenvs.in-project true
+
+# install needed plugins
+poetry self add poetry-plugin-export
+poetry self add 'poethepoet[poetry_plugin]'
+
+# update tooling
+poetry run python -m pip install --upgrade pip
+poetry run python -m pip install --upgrade setuptools
+```
+
+See also:
+
+- https://python-poetry.org/docs/#installation
+- https://poethepoet.natn.io/installation.html
+

--- a/{{cookiecutter.github_repo}}/.github/workflows/package.yml
+++ b/{{cookiecutter.github_repo}}/.github/workflows/package.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Install dependencies
       run: make install 
     - name: Check Python package
-      run: make check
+      run: poetry poet check
     - name: Test Python package
-      run: make test
+      run: poetry poet test

--- a/{{cookiecutter.github_repo}}/.github/workflows/package.yml
+++ b/{{cookiecutter.github_repo}}/.github/workflows/package.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Install dependencies
       run: make install 
     - name: Check Python package
-      run: poetry poet check
+      run: poetry poe check
     - name: Test Python package
-      run: poetry poet test
+      run: poetry poe test

--- a/{{cookiecutter.github_repo}}/.github/workflows/release.yml
+++ b/{{cookiecutter.github_repo}}/.github/workflows/release.yml
@@ -30,9 +30,11 @@ jobs:
         run: make install 
       - run: poetry config pypi-token.pypi "{{ '${{ secrets.PYPI_TOKEN }}' }}"
       - name: Build and publish to pypi
-        run: make publish
+        run: poetry poet publish
       - name: Build and publish Documentation
-        run: make publish-docs
+        run: |
+          poetry poet docs
+          poetry poet docs-publish
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/{{cookiecutter.github_repo}}/.github/workflows/release.yml
+++ b/{{cookiecutter.github_repo}}/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
         run: make install 
       - run: poetry config pypi-token.pypi "{{ '${{ secrets.PYPI_TOKEN }}' }}"
       - name: Build and publish to pypi
-        run: poetry poet publish
+        run: poetry poe publish
       - name: Build and publish Documentation
         run: |
-          poetry poet docs
-          poetry poet docs-publish
+          poetry poe docs
+          poetry poe docs-publish
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/{{cookiecutter.github_repo}}/CONTRIBUTING.md
+++ b/{{cookiecutter.github_repo}}/CONTRIBUTING.md
@@ -32,65 +32,70 @@ Follow [https://github.com/pyenv/pyenv#installation](https://github.com/pyenv/py
 
 ### Python Installation
 
- Do:
-
  `$ pyenv install {{cookiecutter.python_major_version}}.{{cookiecutter.python_minor_version}}`
 
-Note for [MacOS 10.14 user](https://github.com/pyenv/pyenv/issues/544):
-
-  ```bash
-    SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk MACOSX_DEPLOYMENT_TARGET=10.14 pyenv install {{cookiecutter.python_major_version}}.{{cookiecutter.python_minor_version}}
-  ```
 
 ### Poetry Installation: [https://poetry.eustace.io/docs/#installation](https://poetry.eustace.io/docs/#installation)
 
 Poetry will manage our dependencies and create our virtual environment for us.
 
 
-### Integration With Visual Studio Code
-
-Even if we use fabulous tool like pyenv, poetry, ... at the end, we just want to go on, and code.
-
-So here, few detail of my installation.
-
-- .bashrc
-    ```bash
-    # init pyenv with default python version
-    if command -v pyenv 1>/dev/null 2>&1; then
-    eval "$(pyenv init -)"
-    fi
-
-    # add poetry in path
-    export PATH="$HOME/.poetry/bin:$PATH"
-
-    # Add Visual Studio Code (code)
-    export PATH="$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
-    ```
-
-- poetry configuration: all is let with default
-
-- How Launch Visual Studio Code within virtual environment created by poetry ?
-    After do a ```make install```, you have to do:
-    ```bash
-    poetry shell
-    code .
-    ```
-    ```poetry shell``` will activate project virtual environment.
-
 
 ## Make Target list
 
-| Name         | Comment                                                                                         |
-|--------------|-------------------------------------------------------------------------------------------------|
-|              |                                                                                                 |
-| debug-info   | Show poetry debug info                                                                          |
-| install      | Install project dependencies                                                                    |
-| check        | Run linters and static analysis                                                                 |
-| test         | Run unit tests                                                                                  |
-| build        | Builds the source and wheels archives                                                           |
-| build-docs   | Builds  site documentation.                                                                     |
-| tag          | create and push a tag based on current project version. This will launch github release action. |
-| publish      | Publishes the package, previously built with the build command, to the remote repository        |
-| publish-docs | Build and publish site documentation.                                                           |
-| clean        | Delete all generated and temporary files                                                        |
-|              |                                                                                                 |
+
+| Name                    | Comment                                                                                         |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| make install            | Install project dependencies                                                                    |
+| make configure          | Configure poetry                                                                                |
+| make tag                | Create and push a tag based on current project version. This will launch github release action. |
+| make next-patch-version | Increment patch version of the project.                                                         |
+|                         |                                                                                                 |
+
+
+## Poe Target list
+
+
+| Name                    | Comment                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------- |
+| poetry poe check        | Run linters and static analysis                                                          |
+| poetry poe test         | Run unit tests                                                                           |
+| poetry poe build        | Builds the source and wheels archives (and run check & test target)                      |
+| poetry poe publish      | Publishes the package, previously built with the build command, to the remote repository |
+| poetry poe docs         | Builds  site documentation.                                                              |
+| poetry poe docs-publish | Build and publish site documentation.                                                    |
+| poetry poe clean        | Delete all generated and temporary files                                                 |
+| poetry poe requirements | Generate requirements.txt                                                                |
+|                         |                                                                                          |
+
+You could retrieve those commands with `poetry poe`. It will output something like this :
+
+```
+Poe the Poet - A task runner that works well with poetry.
+version 0.25.0
+
+Result: No task specified.
+
+USAGE
+  poetry poe [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]
+
+GLOBAL OPTIONS
+  -h, --help     Show this help page and exit
+  --version      Print the version and exit
+  -v, --verbose  Increase command output (repeatable)
+  -q, --quiet    Decrease command output (repeatable)
+  -d, --dry-run  Print the task contents but don't actually run it
+  --root PATH    Specify where to find the pyproject.toml
+  --ansi         Force enable ANSI output
+  --no-ansi      Force disable ANSI output
+
+CONFIGURED TASKS
+  build          Build module
+  publish        Publish module
+  check          Run Linter
+  test           Run unit tests
+  docs           Build site documentation
+  docs-publish   Publish site documentation
+  clean          Remove all generated and temporary files
+  requirements   Generate requirements.txt
+```

--- a/{{cookiecutter.github_repo}}/Makefile
+++ b/{{cookiecutter.github_repo}}/Makefile
@@ -1,24 +1,7 @@
-# Project settings
-PACKAGE := {{cookiecutter.package_name}}
-REPOSITORY := {{cookiecutter.github_username}}/{{cookiecutter.github_repo}}
-PACKAGES := $(PACKAGE) tests
-MODULES := $(wildcard $(PACKAGE)/*.py)
-
 # const
 .DEFAULT_GOAL := help
-FAILURES := .pytest_cache/v/cache/lastfailed
-DIST_FILES := dist/*.tar.gz dist/*.whl
-
-GIT_COMMIT_SHA := $(shell git rev-parse HEAD)
 
 # MAIN TASKS ##################################################################
-
-.PHONY: all
-all: install
-
-.PHONY: debug-info
-debug-info:  ## Show poetry debug info
-	poetry debug:info
 
 .PHONY: help
 help: all
@@ -30,64 +13,28 @@ install: .install .cache ## Install project dependencies
 
 .install: poetry.lock
 	$(MAKE) configure
-	poetry install
+	poetry install --with docs
 	poetry check
 	@touch $@
 
 poetry.lock: pyproject.toml
 	$(MAKE) configure
 	poetry lock
-	$(MAKE) requirements.txt
 	@touch $@
 
 .cache:
 	@mkdir -p .cache
 
-.PHONY: requirements.txt
-requirements.txt: poetry.lock ## Generate requirements.txt
-	@poetry export --without-hashes -f requirements.txt > requirements.txt
-	@sed '1d' requirements.txt
-
 
 .PHONY: configure
 configure:
 	@poetry config virtualenvs.in-project true
+	@poetry self add poetry-plugin-export
+	@poetry self add 'poethepoet[poetry_plugin]'
 	@poetry run python -m pip install --upgrade pip
 	@poetry run python -m pip install --upgrade setuptools
 
-# CHECKS ######################################################################
-
-.PHONY: check
-check: install   ## Run linters and static analysis
-	poetry run isort $(PACKAGES)
-	poetry run black $(PACKAGES)
-	poetry run ruff check $(PACKAGE)
-	poetry run mypy --show-error-codes --config-file pyproject.toml $(PACKAGE)
-
-# TESTS #######################################################################
-
-.PHONY: test
-test: install ## Run unit tests
-	@if test -e $(FAILURES); then poetry run pytest tests --last-failed --exitfirst; fi
-	@rm -rf $(FAILURES)
-	poetry run pytest
-
-
-# BUILD #######################################################################
-
-.PHONY: build
-build: install check test $(DIST_FILES) ## Builds the source and wheels archives
-$(DIST_FILES): $(MODULES) pyproject.toml
-	@rm -f $(DIST_FILES)
-	poetry build
-
-# RELEASE #####################################################################
-
-.PHONY: publish
-publish: build ## Publishes the package, previously built with the build command, to the remote repository
-	$(MAKE) configure
-	poetry publish
-
+# git util #####################################################################
 
 .PHONY: next-patch-version
 next-patch-version:  ## Increment patch version
@@ -107,27 +54,4 @@ tag:  ## Tags current repository
 	@PROJECT_RELEASE=$$(poetry version | awk 'END {print $$NF}') ; \
 		git tag "v$$PROJECT_RELEASE" ; \
 		git push origin "v$$PROJECT_RELEASE"
-
-.PHONY: release
-release: publish next-patch-version
-
-# DOC #########################################################################
-
-.PHONY: build-docs
-build-docs:  ## Build and publish sit documentation.
-	@git fetch origin  gh-pages
-	@poetry run mkdocs build --clean
-
-
-.PHONY: publish-docs
-publish-docs:  ## Build and publish sit documentation.
-	@poetry run mkdocs gh-deploy  --clean 
-
-
-# CLEANUP #####################################################################
-
-.PHONY: clean
-clean:  ## Delete all generated and temporary files
-	@rm -rf *.spec dist build .eggs *.egg-info .install .cache .coverage htmlcov .mypy_cache .pytest_cache site .ruff_cache
-	@find $(PACKAGES) -type d -name '__pycache__' -exec rm -rf {} +
 

--- a/{{cookiecutter.github_repo}}/pyproject.toml
+++ b/{{cookiecutter.github_repo}}/pyproject.toml
@@ -21,29 +21,39 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
+{% if cookiecutter.use_package_mode == "Enabled" -%}
+packages = [{include = "{{cookiecutter.package_name}}"}]
+{% endif %}
+{% if cookiecutter.use_package_mode == "Disabled" -%}
+package-mode = false
+{% endif %}
+
 
 [tool.poetry.dependencies]
 python = ">={{cookiecutter.python_major_version}}.{{cookiecutter.python_minor_version}},<3.12"
 
-[tool.poetry.dev-dependencies]
-black = "22.3.0"             # The uncompromising code formatter.
-isort = "5.9.3"              #A Python utility / library to sort Python imports.
-ruff = "^0.0.264"
+[tool.poetry.group.dev.dependencies]
+black = "24.2.0"             # The uncompromising code formatter.
+isort = "5.13.2"              #A Python utility / library to sort Python imports.
+ruff = "^0.2.2"
 mypy = "*"
-types-setuptools = "^67.7.0"
+types-setuptools = "^69.1.0"
 
 # Unit Testing
-pytest = "^7"                                   # pytest: simple powerful testing with Python
+pytest = "^8"                                   # pytest: simple powerful testing with Python
 pytest-cov = "^4"                               # Pytest plugin for measuring coverage.
 pytest-mock = "^3"
-xdoctest = "^0.15.0"                            # A rewrite of the builtin doctest module
+xdoctest = "^1.1.3"                            # A rewrite of the builtin doctest module
 coverage = { version = "*", extras = ["toml"] }
 
-# Documentation
-mkdocs = { extras = ["markdown-include"], version = "^1.4.3" }
-mkdocstrings = { extras = ["python"], version = "^0.21.2" }
-mkdocs-material = "^9.1.9"
-mkdocs-include-markdown-plugin = "^4.0.4"
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
+mkdocs = { extras = ["markdown-include"], version = "^1.5.3" }
+mkdocstrings = { extras = ["python"], version = "^0.24.0" }
+mkdocs-material = "^9.5.11"
+mkdocs-include-markdown-plugin = "^6.0.4"
 
 
 [tool.black]
@@ -94,10 +104,60 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 warn_unused_configs = true
 
+
+[tool.poe.tasks]
+_isort = "poetry run isort my_project tests"
+_black = "poetry run black my_project tests"
+_ruff = "poetry run ruff check my_project"
+_mypy = "poetry run mypy --show-error-codes --config-file pyproject.toml my_project"
+_build = "poetry build"
+_publish = "poetry publish"
+build.help = "Build module"
+build.sequence = ["check", "test", "_build"]
+publish.help = "Publish module"
+publish.sequence = ["build", "_publish"]
+check.help = "Run Linter"
+check.sequence = ["_isort", "_black", "_ruff", "_mypy"]
+
+
+[tool.poe.tasks.test]
+help = "Run unit tests"
+shell = """
+if test -e .cache/v/cache/lastfailed; then poetry run pytest tests --last-failed --exitfirst; fi &
+rm -rf .cache/v/cache/lastfailed &
+poetry run pytest
+"""
+
+[tool.poe.tasks.docs]
+help = "Build site documentation"
+shell  = """
+git fetch origin gh-pages &
+poetry run mkdocs build --clean
+"""
+
+[tool.poe.tasks.docs-publish]
+help = "Publish site documentation"
+cmd  = """
+poetry run mkdocs gh-deploy  --clean 
+"""
+
+[tool.poe.tasks.clean]
+help = "Remove all generated and temporary files"
+shell  = """
+rm -rf *.spec dist build .eggs *.egg-info .install .cache .coverage htmlcov .mypy_cache .pytest_cache site .ruff_cache &
+find {{cookiecutter.package_name}} tests -type d -name '__pycache__' -exec rm -rf {} +
+"""
+
+[tool.poe.tasks.requirements]
+help = "Generate requirements.txt"
+cmd = "poetry export --without-hashes -f requirements.txt "
+capture_stdout = "requirements.txt"
+
+
 [build-system]
 requires = ["poetry>=1.1.12"]
 build-backend = "poetry.masonry.api"
 
-# Exqmple
+# Scripts Example
 #[tool.poetry.scripts]
 #rascal = "{{cookiecutter.package_name}}.cli:main"


### PR DESCRIPTION
Use poethepoet (https://github.com/nat-n/poethepoet) to replace most of command declared into makefile:

Example: poetry poe

Poe the Poet - A task runner that works well with poetry.
version 0.25.0

Result: No task specified.

USAGE
  poetry poe [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]

GLOBAL OPTIONS
  -h, --help     Show this help page and exit
  --version      Print the version and exit
  -v, --verbose  Increase command output (repeatable)
  -q, --quiet    Decrease command output (repeatable)
  -d, --dry-run  Print the task contents but don't actually run it
  --root PATH    Specify where to find the pyproject.toml
  --ansi         Force enable ANSI output
  --no-ansi      Force disable ANSI output

CONFIGURED TASKS
  build          Build module
  publish        Publish module
  check          Run Linter
  test           Run unit tests
  docs           Build site documentation
  docs-publish   Publish site documentation
  clean          Remove all generated and temporary files
  requirements   Generate requirements.txt


